### PR TITLE
Fix render event when timeslotsPerHour is 1

### DIFF
--- a/full_demo/demo.js
+++ b/full_demo/demo.js
@@ -213,11 +213,11 @@ $(document).ready(function() {
          var startTime = timeslotTimes[i].start;
          var endTime = timeslotTimes[i].end;
          var startSelected = "";
-         if (startTime.getTime() === calEvent.start.getTime()) {
+         if (Math.round(startTime.getTime()/1000) === Math.round(calEvent.start.getTime()/1000)) {
             startSelected = "selected=\"selected\"";
          }
          var endSelected = "";
-         if (endTime.getTime() === calEvent.end.getTime()) {
+         if (Math.round(endTime.getTime()/1000) === Math.round(calEvent.end.getTime()/1000)) {
             endSelected = "selected=\"selected\"";
          }
          $startTimeField.append("<option value=\"" + startTime + "\" " + startSelected + ">" + timeslotTimes[i].startFormatted + "</option>");

--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -1005,7 +1005,11 @@
 
                var $newEvent = $("<div class=\"wc-cal-event wc-new-cal-event wc-new-cal-event-creating\"></div>");
 
-               $newEvent.css({lineHeight: (options.timeslotHeight - 2) + "px", fontSize: (options.timeslotHeight / 2) + "px"});
+               if (options.timeslotsPerHour == 1 && options.timeslotHeight > 25) {
+                  $newEvent.css({lineHeight: ((options.timeslotHeight / 2)-1) + "px", fontSize: (options.timeslotHeight / 4) + "px"});
+               } else {
+                  $newEvent.css({lineHeight: (options.timeslotHeight - 2) + "px", fontSize: (options.timeslotHeight / 2) + "px"});
+               }
                $target.append($newEvent);
 							 
                var columnOffset = $target.offset().top;


### PR DESCRIPTION
Hi, I found a bug when implementig week calendar for my site, that is,
an event renders two lines of text (event time in one line, title in a
second line) and currently the logic is to render each of them on a
timeslot, so you need at least a timeslotsPerHour of 2 so the two
lines look fine, the case is I use a timeslotsPerHour of 1 with enough
height to show the two lines, but week calendar is not doing so.

The fix is for your master branch although I originally made the fix for
 1.2.2 version (my project uses jquery 1.3.2). 
I made two screenshots of before and after the patch:

Before: http://www.meneame.net/backend/media.php?type=post&id=696616&image.jpg
After: http://www.meneame.net/backend/media.php?type=post&id=696618&image.jpg

I also handle the case someone use one and small timeslotperhour(<26px)
in that case we keep current behaviour and only one line is shown.

I would also take the chance to request you about backporting some
patches to a jquery 1.3.2 branch, there's a lot of people like me that
use jquery-1.3.2 and for a reason (my projects use plugins that dont
have a jquery 1.4 version, and so I cant switch).. and not all patches
but important ones (like the daylight savings one..)

Thank you for an awesome jquery week calendar!
