### PR TITLE
Css order bug & dbl click event

### DIFF
--- a/jquery.weekcalendar.css
+++ b/jquery.weekcalendar.css
@@ -1,5 +1,4 @@
 
-
 .wc-container {
 	font-size: 14px;	
 	font-family: arial, helvetica;
@@ -210,7 +209,7 @@ table.wc-time-slots {
   /* IE 5-7 */ filter: alpha(opacity=80);
   /* Netscape */ -moz-opacity: 0.8;
   /* Safari 1 */ -khtml-opacity: 0.8;
-	position: absolute;	
+	position: absolute!important;	
 	text-align: center;
 	overflow: hidden;
 	cursor: pointer;

--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -76,6 +76,9 @@
         eventClick: function(calEvent, element, dayFreeBusyManager, 
                                                       calendar, clickEvent) {
         },
+        eventDblClick: function(calEvent, element, dayFreeBusyManager, 
+                                                      calendar, clickEvent) {
+        },
         eventRender: function(calEvent, element) {
           return element;
         },
@@ -601,7 +604,17 @@
             if ($target.data('sizing')) { return;}
             options.eventMouseout($target.data('calEvent'), $target, event);
           }
-        });
+        }).dblclick(function(event){
+		  var $target = $(event.target),freeBusyManager;
+          if ($target.data('preventClick')) {
+            return;
+          }
+          var $calEvent = $target.hasClass('wc-cal-event') ? $target : $target.parents('.wc-cal-event');
+          if ($calEvent.length) {
+            freeBusyManager = self.getFreeBusyManagerForEvent($calEvent.data('calEvent'));
+            options.eventDblClick($calEvent.data('calEvent'), $calEvent, freeBusyManager, self.element, event);
+          }
+		});
       },
 
       /*


### PR DESCRIPTION
Makes sure you override the position relative from jqueryui.css even if it's loaded afterwards,
I lost 3 hours wondering why all of my events were off to finally realise that if you load the weekcalendar css before jquery ui, position becomes relative instead of absolute...
