### PR TITLE
New option "totalEventsWidthPercentInOneColumn"

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -65,6 +65,7 @@
         scrollToHourMillis: 500,
         allowCalEventOverlap: false,
         overlapEventsSeparate: false,
+        totalEventsWidthPercentInOneColumn : 100,
         readonly: false,
         allowEventCreation: true,
         draggable: function(calEvent, element) {
@@ -1438,11 +1439,11 @@
 
                   // do we want events to be displayed as overlapping
                   if (self.options.overlapEventsSeparate) {
-                      var newWidth = 100 / curGroups.length;
+                      var newWidth = self.options.totalEventsWidthPercentInOneColumn / curGroups.length;
                       var newLeft = groupIndex * newWidth;
                   } else {
                       // TODO what happens when the group has more than 10 elements
-                      var newWidth = 100 - ((curGroups.length - 1) * 10);
+                      var newWidth = self.options.totalEventsWidthPercentInOneColumn - ((curGroups.length - 1) * 10);
                       var newLeft = groupIndex * 10;
                   }
                   $.each(curGroup, function() {

--- a/weekcalendar_demo_4.html
+++ b/weekcalendar_demo_4.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN""http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+<head>
+<style type='text/css'>
+
+	body {
+		font-family: "Lucida Grande",Helvetica,Arial,Verdana,sans-serif;
+		margin: 0;
+	}
+	
+	h1 {
+		margin: 0 0 1em;
+		padding: 0.5em;
+	}
+	
+	p.description {
+		font-size: 0.8em;
+		padding: 1em;
+		position: absolute;
+		top: 3.2em;
+		margin-right: 400px;
+	}
+	
+	#message {
+		font-size: 0.7em;
+		position: absolute;
+		top: 1em; 
+		right: 1em;
+		width: 350px;
+		display: none;
+		padding: 1em;
+		background: #ffc;
+		border: 1px solid #dda;
+	}
+	
+</style>
+    <!--
+	<link rel='stylesheet' type='text/css' href='http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.9/themes/base/jquery-ui.css' />
+	-->
+
+    <link rel='stylesheet' type='text/css' href='libs/css/smoothness/jquery-ui-1.8.11.custom.css' />
+
+
+	<link rel='stylesheet' type='text/css' href='jquery.weekcalendar.css' />
+
+
+	   <!--
+	<script type='text/javascript' src='http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js'></script>
+    <script type='text/javascript' src='http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.9/jquery-ui.min.js'></script>
+    -->
+
+   <script type='text/javascript' src='libs/jquery-1.4.4.min.js'></script>
+    <script type='text/javascript' src='libs/jquery-ui-1.8.11.custom.min.js'></script>
+	<script type="text/javascript" src="libs/date.js"></script>
+	<script type='text/javascript' src='jquery.weekcalendar.js'></script>
+<script type='text/javascript'>
+
+ 
+	var year = new Date().getFullYear();
+	var month = new Date().getMonth();
+	var day = new Date().getDate();
+
+	var eventData = {
+		events : [
+		   {"id":1, "start": new Date(year, month, day, 12), "end": new Date(year, month, day, 13, 35),"title":"Lunch with Mike"},
+		   {"id":2, "start": new Date(year, month, day, 14), "end": new Date(year, month, day, 14, 45),"title":"Dev Meeting"},
+		   {"id":3, "start": new Date(year, month, day + 1, 18), "end": new Date(year, month, day + 1, 18, 45),"title":"Hair cut"},
+		   {"id":4, "start": new Date(year, month, day - 1, 8), "end": new Date(year, month, day - 1, 9, 30),"title":"Team breakfast"},
+		   {"id":5, "start": new Date(year, month, day + 1, 14), "end": new Date(year, month, day + 1, 16),"title":"Product showcase"},
+		   {"id":5, "start": new Date(year, month, day + 1, 15), "end": new Date(year, month, day + 1, 17),"title":"Overlay event"}
+		]
+	};
+
+
+	   
+	$(document).ready(function() {
+
+		$('#calendar').weekCalendar({
+			timeslotsPerHour: 4,
+			allowCalEventOverlap: true,
+			overlapEventsSeparate: true,
+			totalEventsWidthPercentInOneColumn : 95,
+
+			height: function($calendar){
+				return $(window).height() - $("h1").outerHeight(true);
+			},
+			eventRender : function(calEvent, $event) {
+				if(calEvent.end.getTime() < new Date().getTime()) {
+					$event.css("backgroundColor", "#aaa");
+					$event.find(".time").css({"backgroundColor": "#999", "border":"1px solid #888"});
+				}
+			},
+			eventNew : function(calEvent, $event) {
+				displayMessage("<strong>Added event</strong><br/>Start: " + calEvent.start + "<br/>End: " + calEvent.end);
+				alert("You've added a new event. You would capture this event, add the logic for creating a new event with your own fields, data and whatever backend persistence you require.");
+			},
+			eventDrop : function(calEvent, $event) {
+				displayMessage("<strong>Moved Event</strong><br/>Start: " + calEvent.start + "<br/>End: " + calEvent.end);
+			},
+			eventResize : function(calEvent, $event) {
+				displayMessage("<strong>Resized Event</strong><br/>Start: " + calEvent.start + "<br/>End: " + calEvent.end);
+			},
+			eventClick : function(calEvent, $event) {
+				displayMessage("<strong>Clicked Event</strong><br/>Start: " + calEvent.start + "<br/>End: " + calEvent.end);
+			},
+			eventMouseover : function(calEvent, $event) {
+				displayMessage("<strong>Mouseover Event</strong><br/>Start: " + calEvent.start + "<br/>End: " + calEvent.end);
+			},
+			eventMouseout : function(calEvent, $event) {
+				displayMessage("<strong>Mouseout Event</strong><br/>Start: " + calEvent.start + "<br/>End: " + calEvent.end);
+			},
+			noEvents : function() {
+				displayMessage("There are no events for this week");
+			},
+			data:eventData
+		});
+
+		function displayMessage(message) {
+			$("#message").html(message).fadeIn();
+		}
+
+		$("<div id=\"message\" class=\"ui-corner-all\"></div>").prependTo($("body"));
+		
+	});
+
+</script>
+</head>
+<body>
+	<h1>Week Calendar Demo</h1>
+	<p class="description">This calendar demonstrates a basic calendar. Events triggered are displayed in the message area. Appointments in the past are shaded grey.<br/>
+	This calendar demonstrates overlapped events with little space on right to create new events	(new option <i>"totalEventsWidthPercentInOneColumn"</i>)</p>	
+	<div id='calendar'></div>
+	
+</body>
+</html>


### PR DESCRIPTION
Add new option to specify total overlapped events width in percent to allow to allow small space on the right to create new event
- Add new option "totalEventsWidthPercentInOneColumn" with default value = 100 (100%) for compatibility
- Setting this option to 95 (for example) with allowCalEventOverlap=true will let small space on the right of overlapped events (5% width)
- This small space allow user to create new event during overlapped events
- Demo file weekcalendar_demo_4.html added to show this new feature
