### PR TITLE
Fix bug with buttons = false option

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -715,6 +715,13 @@
             $calendarContainer.find('.wc-title')
               .height(_height)
               .css('line-height', _height + 'px');
+        }else{
+            var calendarNavHtml = '';
+            calendarNavHtml += '<div class=\"ui-widget-header wc-toolbar\">';
+              calendarNavHtml += '<h1 class=\"wc-title\"></h1>';
+            calendarNavHtml += '</div>';
+            $(calendarNavHtml).appendTo($calendarContainer);
+
         }
       },
 


### PR DESCRIPTION
Elsewhere in the code was expecting the title header that was built by
the button render function which got disabled with buttons = false.

Added an else clause to put just the header back to make the system
happy.
