### PR TITLE
Added background-color support for event-data.

### DIFF
--- a/jquery.weekcalendar.css
+++ b/jquery.weekcalendar.css
@@ -157,7 +157,7 @@ table.wc-time-slots {
 
 
 .wc-time-header-cell {
-	padding: 5px;	
+	padding: 5px;
 	height: 80px; /* reference height */
 }
 

--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -704,6 +704,13 @@
                       var _id = 'wc-switch-display-' + option;
                       var _input = $('<input type="radio" id="' + _id + '" name="wc-switch-display" class="wc-switch-display"/>');
                       var _label = $('<label for="' + _id + '"></label>');
+
+                      if(typeof(I18n) != 'undefined'){
+                          label = I18n.t(label);
+                      }
+
+                      //var localizedLabel = I18n.t(label);
+
                       _label.html(label);
                       _input.val(option);
                       if (parseInt(self.options.daysToShow, 10) === parseInt(option, 10)) {
@@ -1040,7 +1047,14 @@
 
                 var $newEvent = $('<div class=\"wc-cal-event wc-new-cal-event wc-new-cal-event-creating\"></div>');
 
-                $newEvent.css({lineHeight: (options.timeslotHeight - 2) + 'px', fontSize: (options.timeslotHeight / 2) + 'px'});
+                var css = {
+                    'background-color': 'yellow',
+                    lineHeight: (options.timeslotHeight - 2) + 'px',
+                    fontSize: (options.timeslotHeight / 2) + 'px'
+                };
+
+                //$newEvent.css({lineHeight: (options.timeslotHeight - 2) + 'px', fontSize: (options.timeslotHeight / 2) + 'px'});
+                $newEvent.css(css);
                 $target.append($newEvent);
 
                 var columnOffset = $target.offset().top;
@@ -1409,16 +1423,31 @@
 
           var eventClass, eventHtml, $calEventList, $modifiedEvent;
 
+          /* add color support
+          *  @author Daniel Schmidt, Datenspiel GmbH 2011
+          * */
+          var eventCSS = {
+              lineHeight: (options.textSize + 2) + 'px',
+              fontSize: options.textSize + 'px'
+          };
+
+
+          if(calEvent.hasOwnProperty("color")){
+              jQuery.extend(eventCSS,{'background-color': calEvent.color});
+          }
+
+          /* end color support */
+
           eventClass = calEvent.id ? 'wc-cal-event' : 'wc-cal-event wc-new-cal-event';
           eventHtml = '<div class=\"' + eventClass + ' ui-corner-all\">';
           eventHtml += '<div class=\"wc-time ui-corner-top\"></div>';
           eventHtml += '<div class=\"wc-title\"></div></div>';
-
           $weekDay.each(function() {
             var $calEvent = $(eventHtml);
+
             $modifiedEvent = options.eventRender(calEvent, $calEvent);
             $calEvent = $modifiedEvent ? $modifiedEvent.appendTo($(this)) : $calEvent.appendTo($(this));
-            $calEvent.css({lineHeight: (options.textSize + 2) + 'px', fontSize: options.textSize + 'px'});
+            $calEvent.css(eventCSS);
 
             self._refreshEventDetails(calEvent, $calEvent);
             self._positionEvent($(this), $calEvent);


### PR DESCRIPTION
Hi, 

it's just a simple hack. We needed different colors for our events, so I added a property color to the event object. 

``` javascript
var eventData = {
    events : [
       {"id":1, "start": new Date(year, month, day, 12), "end": new Date(year, month, day+1, 13, 35),"title":"Lunch with Mike", color:"green"},
       {"id":3, "start": new Date(year, month, day + 1, 18), "end": new Date(year, month, day + 1, 18, 45),"title":"Hair cut"},
       {"id":4, "start": new Date(year, month, day - 1, 8), "end": new Date(year, month, day - 1, 9, 30),"title":"Team breakfast"},
       {"id":5, "start": new Date(year, month, day + 1, 14), "end": new Date(year, month, day + 1, 15),"title":"Product showcase"}
    ]
};
```

If there is another solution just ignore my request. 

Best regards,

Daniel
