### PR TITLE
Bugfix when multiday events span Sunday at midnight

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -1352,11 +1352,12 @@
               var maxHour = self.options.businessHours.limitDisplay ? self.options.businessHours.end : 24;
               var minHour = self.options.businessHours.limitDisplay ? self.options.businessHours.start : 0;
               var start = new Date(initialStart);
-              var endDay = initialEnd.getDay();
+              var startDate = self._formatDate(start, 'Ymd');
+              var endDate = self._formatDate(initialEnd, 'Ymd');
               var $weekDay;
               var isMultiday = false;
 
-              while (start.getDay() < endDay) {
+              while (startDate < endDate) {
                 calEvent.start = start;
                 //end of this virual calEvent is set to the end of the day
                 calEvent.end.setFullYear(start.getFullYear());
@@ -1373,6 +1374,7 @@
                 start.setHours(minHour);
                 start.setMinutes(0);
                 start.setSeconds(0);
+                startDate = self._formatDate(start, 'Ymd');
                 isMultiday = true;
               }
               if (start <= initialEnd) {


### PR DESCRIPTION
I discovered a bug when multiday events span Sunday at midnight.

Any multiday events beginning after Sunday at midnight, and ending before the following Sunday at midnight, would appear as you expect.  However, any event which spans Sunday at midnight will not be rendered on the calendar at all.

The current logic uses the JS getDay() function, which returns a value from 0 - 6.  When the event enters Sunday, the getDay() wraps from 6 --> 0, which breaks the current logic.

Instead of comparing the value of getDay(), it is safer to compare 'Ymd', i.e. 20110925 (a Sunday) which is greater than 20110924 (a Saturday).

This change does exactly that, and fixes the bug.  Events spanning Sunday at midnight now correctly as appear as expected.
