### PR TITLE
removed Date.parse(d) as it was returning a number instead of a date obje

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -2087,7 +2087,7 @@
               return this._cleanDate(parseInt(d, 10));
             }
             // this is a human readable date
-            return Date.parse(d) || new Date(d);
+            return new Date(d);
           }
           if (typeof d == 'number') {
             return new Date(d);


### PR DESCRIPTION
removed Date.parse(d) as it was returning a number instead of a date object. this would fail later on when it attempts to call the getTime() method on it.
