### PR TITLE
Allow preventing event creation in beforeEventNew

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -1105,12 +1105,17 @@
                   self._adjustOverlappingEvents($weekDay);
                 }
 
-                self._trigger('beforeEventNew', event, {
+                var proceed = self._trigger('beforeEventNew', event, {
                   'calEvent': newCalEvent,
                   'createdFromSingleClick': createdFromSingleClick,
                   'calendar': self.element
                 });
-                options.eventNew(newCalEvent, $renderedCalEvent, freeBusyManager, self.element, event);
+  							if (proceed) {
+									options.eventNew(newCalEvent, $renderedCalEvent, freeBusyManager, self.element, event);
+								}
+								else {
+									$($renderedCalEvent).remove();
+								}
             }
           });
       },


### PR DESCRIPTION
You should be able to just return false from beforeEventNew to prevent the event from being created
