### PR TITLE
Mouseover events did not always trigger

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -615,6 +615,9 @@
           if ($target.hasClass('wc-cal-event')) {
             options.eventMouseover($target.data('calEvent'), $target, event);
           }
+          if ($target.hasClass('wc-time') || $target.hasClass('wc-title')) {
+            options.eventMouseover($target.parents('.wc-cal-event').data('calEvent'), $target, event);
+          }
         }).mouseout(function(event) {
           var $target = $(event.target);
           if (self._isDraggingOrResizing($target)) {
@@ -623,6 +626,10 @@
           if ($target.hasClass('wc-cal-event')) {
             if ($target.data('sizing')) { return;}
             options.eventMouseout($target.data('calEvent'), $target, event);
+          }
+          if ($target.hasClass('wc-time') || $target.hasClass('wc-title')) {
+            if ($target.data('sizing')) { return;}
+            options.eventMouseout($target.parents('.wc-cal-event').data('calEvent'), $target, event);
           }
         });
       },


### PR DESCRIPTION
While working with this plugin, I discovered that mouseover/out events would not trigger if you hovered over the title and time.  I believe this has to do with the child divs clearing the event.  This worked on any empty space though from the event (such as if it was 3 hours long with a really short title).

This seems to resolve it nicely.
