### PR TITLE
Issue with multiple scrollbars (IE)

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -1054,6 +1054,8 @@
                 $target.append($newEvent);
 
                 var columnOffset = $target.offset().top;
+				if($.browser.msie && $.browser.version < 9)
+					columnOffset += window.document.documentElement.scrollTop;
                 var clickY = event.pageY - columnOffset;
                 var clickYRounded = (clickY - (clickY % options.timeslotHeight)) / options.timeslotHeight;
                 var topPosition = clickYRounded * options.timeslotHeight;


### PR DESCRIPTION
The issue appear when there are 2 scrollbars in the page.
The main scrollbar isn't added automaticaly in $target.offset().top for IE (version < 9)
So when I try to select an interval, the selection is shifted by the size of the first scrollbar.

Add to the current offset, the scrollTop value of window.document.documentElement fix the issue.
