### PR TITLE
Added showHeader option to completely disable header (including buttons)

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -55,6 +55,7 @@
         timeslotsPerHour: 4,
         minDate: null,
         maxDate: null,
+        showHeader: true,
         buttons: true,
         buttonText: {
           today: 'today',
@@ -688,6 +689,7 @@
         */
       _renderCalendarButtons: function($calendarContainer) {
         var self = this, options = this.options;
+        if ( !options.showHeader ) return;
         if (options.buttons) {
             var calendarNavHtml = '';
 


### PR DESCRIPTION
Hi,

I added a new option to disable header completely, including buttons. The name of the option is showHeader and it's default value is true. I consider this can be useful in some cases, and allows more flexibility.

Regards,
