### PR TITLE
Setting options that re-render kills all current events

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -531,7 +531,7 @@
           // events array locally in a store but this should be done in conjunction
           // with a proper binding model.
 
-          var currentEvents = $.map(self.element.find('.wc-cal-event'), function() {
+          var currentEvents = self.element.find('.wc-cal-event').map(function() {
             return $(this).data('calEvent');
           });
 


### PR DESCRIPTION
Instead of using $.map where this refers to the window,
we use $(elements).map, which will map this to the
element that we want

This is a problem when setting options and re-rendering, 
and current events on the calendar is not re-displayed
