### PR TITLE
Drag ignores freeBusy fix

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -1729,6 +1729,35 @@
           var adjustedStart, adjustedEnd;
           var self = this;
 
+          var freeBusyManager = self.getFreeBusyManagerForEvent(newCalEvent);
+          $.each(freeBusyManager.getFreeBusys(newCalEvent.start, newCalEvent.end), function() {
+              if (!this.getOption('free')) {
+
+                  if (newCalEvent.start.getTime() == this.getStart().getTime() &&
+                      newCalEvent.end.getTime() > this.getEnd().getTime()) {
+
+                      adjustedStart = this.getEnd();
+                  }
+
+                  if (newCalEvent.end.getTime() == this.getEnd().getTime() &&
+                      newCalEvent.start.getTime() < this.getStart().getTime()) {
+
+                      adjustedEnd = this.getStart();
+                  }
+
+                  if (oldCalEvent.resizable == false ||
+                      (newCalEvent.end.getTime() > this.getEnd().getTime() &&
+                       newCalEvent.start.getTime() < this.getStart().getTime()) ||
+                      (newCalEvent.end.getTime() == this.getEnd().getTime() &&
+                       newCalEvent.start.getTime() == this.getStart().getTime())) {
+
+                      adjustedStart = oldCalEvent.start;
+                      adjustedEnd = oldCalEvent.end;
+                      newCalEvent.userId = oldCalEvent.userId;
+                  }
+              }
+          });
+
           $weekDay.find('.wc-cal-event').not($calEvent).each(function() {
             var currentCalEvent = $(this).data('calEvent');
 
@@ -1753,6 +1782,7 @@
 
                 adjustedStart = oldCalEvent.start;
                 adjustedEnd = oldCalEvent.end;
+                newCalEvent.userId = oldCalEvent.userId;
                 return false;
             }
 


### PR DESCRIPTION
Fixed ignoring of freeBusy areas when dragging and resizing events. Fixed bug with userId in some cases.
