### PR TITLE
Fix multi day event rendering.

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -1433,6 +1433,7 @@
 
           while (startDate < endDate) {
             calEvent.start = start;
+            calEvent.end = newDate(0, 0, 0);
 
             // end of this virual calEvent is set to the end of the day
             calEvent.end.setFullYear(start.getFullYear());


### PR DESCRIPTION
Fix for two issues:
1. _"calEvent.end.setFullYear is not a function"_ and not rendering multi day events at all
2. when there is multi day event, events should be returned ordered by date - with this line it is not needed anymore

tested with JQuery UI 1.8.12, Safari 6.0, FF 14.0.1
