### PR TITLE
jQuery 1.9 support

### DIFF
--- a/jquery.weekcalendar.js
+++ b/jquery.weekcalendar.js
@@ -2020,9 +2020,9 @@
        */
       _disableTextSelect: function($elements) {
           $elements.each(function() {
-            if ($.browser.mozilla) {//Firefox
+            if (typeof this.style.MozUserSelect !== 'undefined') {//Firefox
                 $(this).css('MozUserSelect', 'none');
-            } else if ($.browser.msie) {//IE
+            } else if (typeof this.onselectstart !== 'undefined') {//IE
                 $(this).bind('selectstart', function() {
                   return false;
                 });


### PR DESCRIPTION
I've replaced use of the (deprecated, now removed) jQuery.browser() method, with support checks instead. This provides compatibility with jQuery 1.9 and above.

Hope that's helpful,

Ross
